### PR TITLE
zipcode value is string, change to value.length

### DIFF
--- a/src/containers/Checkout/ContactData/ContactData.js
+++ b/src/containers/Checkout/ContactData/ContactData.js
@@ -134,11 +134,11 @@ class ContactData extends Component {
     }
 
     if(rules.minLength) {
-      isValid = value.minLength >= rules.minLength && isValid;
+      isValid = value.length >= rules.minLength && isValid;
     }
 
     if(rules.maxLength) {
-      isValid = value.maxLength >= rules.maxLength && isValid;
+      isValid = value.length <= rules.maxLength && isValid;
     }
 
     return isValid;


### PR DESCRIPTION
fixed `zipCode.valid` is false, `value.minLength` is undefined because value is string. Changed to `value.length`